### PR TITLE
Upgrade to Spring Boot 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.2.7.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.3.3.RELEASE")
     }
 }
 
@@ -25,9 +25,9 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile("org.springframework.boot:spring-boot-starter:1.3.0.RELEASE")
-    compile("org.springframework:spring-jms:4.2.0.RELEASE")
-    compile("com.fasterxml.jackson.core:jackson-databind:2.6.3")
+    compile("org.springframework.boot:spring-boot-starter")
+    compile("org.springframework:spring-jms")
+    compile("com.fasterxml.jackson.core:jackson-databind")
     compile("org.apache.activemq:activemq-broker")
     compile('io.reactivex:rxjava:1.1.1')
     testCompile("junit:junit")

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     compile("com.fasterxml.jackson.core:jackson-databind")
     compile("org.apache.activemq:activemq-broker")
     compile('io.reactivex:rxjava:1.1.1')
+	compile('org.springframework.boot:spring-boot-configuration-processor')
     testCompile("junit:junit")
 }
 

--- a/src/main/java/hello/Application.java
+++ b/src/main/java/hello/Application.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jms.DefaultJmsListenerContainerFactoryConfigurer;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
@@ -19,6 +20,7 @@ import org.springframework.jms.support.converter.MessageType;
 import org.springframework.util.FileSystemUtils;
 
 @SpringBootApplication
+@EnableConfigurationProperties(ApplicationProperties.class)
 public class Application {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Application.class);

--- a/src/main/java/hello/ApplicationProperties.java
+++ b/src/main/java/hello/ApplicationProperties.java
@@ -1,0 +1,32 @@
+package hello;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Sample app configuration. Coupled with the meta-data processor, this provides
+ * auto-completion for your configuration in modern IDEs.
+ *
+ * @author Stephane Nicoll
+ */
+@ConfigurationProperties("app")
+public class ApplicationProperties {
+
+	private final Jms jms = new Jms();
+
+	public Jms getJms() {
+		return jms;
+	}
+
+	static class Jms {
+
+		private String todoQueue;
+
+		public String getTodoQueue() {
+			return todoQueue;
+		}
+
+		public void setTodoQueue(String todoQueue) {
+			this.todoQueue = todoQueue;
+		}
+	}
+}

--- a/src/main/java/hello/TodoEventHandler.java
+++ b/src/main/java/hello/TodoEventHandler.java
@@ -18,7 +18,7 @@ public class TodoEventHandler {
      * Handle incoming {@link TodoEvent} by logging it's information.
      * @param todoEvent
      */
-    @JmsListener(destination = "todo-destination")
+    @JmsListener(destination = "${app.jms.todo-queue}")
     public void handleTodo(TodoEvent todoEvent) {
         LOG.info("handleTodo({}), {}", todoEvent.getId(), todoEvent.getTodoItem());
     }

--- a/src/main/java/hello/TodoEventHandler.java
+++ b/src/main/java/hello/TodoEventHandler.java
@@ -3,9 +3,13 @@ package hello;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.jms.annotation.JmsListener;
+import org.springframework.stereotype.Component;
+
 /**
  * Created by ton on 06/03/16.
  */
+@Component
 public class TodoEventHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(TodoEventHandler.class);
@@ -14,6 +18,7 @@ public class TodoEventHandler {
      * Handle incoming {@link TodoEvent} by logging it's information.
      * @param todoEvent
      */
+    @JmsListener(destination = "todo-destination")
     public void handleTodo(TodoEvent todoEvent) {
         LOG.info("handleTodo({}), {}", todoEvent.getId(), todoEvent.getTodoItem());
     }

--- a/src/main/java/hello/TodoEventSender.java
+++ b/src/main/java/hello/TodoEventSender.java
@@ -15,19 +15,21 @@ import org.springframework.stereotype.Service;
 public class TodoEventSender {
 
     private final JmsTemplate jmsTemplate;
+	private final ApplicationProperties properties;
 
     private static final Logger LOG = LoggerFactory.getLogger(TodoEventSender.class);
 
 	@Autowired
-    public TodoEventSender(JmsTemplate jmsTemplate) {
+    public TodoEventSender(JmsTemplate jmsTemplate, ApplicationProperties properties) {
         this.jmsTemplate = jmsTemplate;
-        LOG.info("initialized");
+		this.properties = properties;
+		LOG.info("initialized");
     }
 
     public void sendEvent(TodoEvent event) {
         LOG.info("sendEvent({},{},{})",
                 event.getId(), event.getEventType(), event.getTodoItem().getText());
-        jmsTemplate.convertAndSend("todo-destination", event);
+        jmsTemplate.convertAndSend(this.properties.getJms().getTodoQueue(), event);
     }
 
 }

--- a/src/main/java/hello/TodoEventSender.java
+++ b/src/main/java/hello/TodoEventSender.java
@@ -2,18 +2,23 @@ package hello;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jms.core.JmsTemplate;
+import org.springframework.stereotype.Service;
 
 /**
  * Sends a {@link TodoEvent} as a JSON text message.
  * Created by ton on 06/03/16.
  */
+@Service
 public class TodoEventSender {
 
     private final JmsTemplate jmsTemplate;
 
     private static final Logger LOG = LoggerFactory.getLogger(TodoEventSender.class);
 
+	@Autowired
     public TodoEventSender(JmsTemplate jmsTemplate) {
         this.jmsTemplate = jmsTemplate;
         LOG.info("initialized");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,5 @@ spring.activemq.password=admin
 
 # switch from queue to topic if true
 # spring.jms.isPubSubDomain=true
+
+app.jms.todo-queue=todo-destination


### PR DESCRIPTION
This example can be further simplified by using the  `@JmsListener`
infrastructure. The `MessageConverter` can be easily associated to a
custom factory via a configurer as illustrated in the configuration.
